### PR TITLE
Add tzdata to set timezone in CircleCI 2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV CLOUDSDK_PYTHON_SITEPACKAGES 1
 ENV PATH /google-cloud-sdk/bin:$PATH
 ENV HOME /
 
-RUN apk --update --no-cache add py2-pip py-crcmod git tar gzip bash curl && \
+RUN apk --update --no-cache add py2-pip py-crcmod git tar gzip bash curl tzdata && \
   pip install crcmod && \
   curl https://sdk.cloud.google.com | bash && \
   gcloud components update && \


### PR DESCRIPTION
As described in [the document](https://circleci.com/docs/2.0/migrating-from-1-2/#timezone), to set timezone in CircleCI 2.0, we need tzdata.